### PR TITLE
fix bug resulting in accidental data loss

### DIFF
--- a/src/pyprinttags.py
+++ b/src/pyprinttags.py
@@ -42,7 +42,7 @@ def script():
                 inputFunction = raw_input
             else:
                 inputFunction = input
-            if not args.batch and inputFunction("remove unsupported properties? [yN] ") in "yY":
+            if not args.batch and inputFunction("remove unsupported properties? [yN] ").lower() in ["y", "yes"]:
                 audioFile.removeUnsupportedProperties(audioFile.unsupported)
                 audioFile.save()
 


### PR DESCRIPTION
When the user does not enter any string and just presses Enter, it results in empty string being the answer. The problem is that empty string is a substring of every string:
```
>>> "" in "yY"
True
```
Also, the _substring_ test itself is not appropriate here because it results in undesired behaviour and might cause accidental data loss.