### PR TITLE
Create .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y libtag1-dev
+python:
+- 2.7
+- 3.6
+
+script:
+  - python setup.py build
+  - python setup.py test


### PR DESCRIPTION
Enables continuous integration (build + unit tests for python 2.7 and python 3.6)