### PR TITLE
Fix missing *.m4a data test for pypi package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,4 +4,4 @@ include doc/pyprinttags.1
 include src/*.pxd
 include src/*.pyx
 include src/taglib.cpp
-recursive-include tests *.py *.flac *.mp3
+recursive-include tests *.py *.flac *.mp3 *.m4a


### PR DESCRIPTION
Prior to this complete, the data set for tests was incomplete

Related #46