### PR TITLE
convert File.path to pathlib.Path and allow os.PathLike in constructor

### DIFF
--- a/src/taglib.pyx
+++ b/src/taglib.pyx
@@ -8,6 +8,8 @@
 # published by the Free Software Foundation
 
 from libcpp.utility cimport pair
+from os import PathLike
+from pathlib import Path
 cimport ctypes
 
 version = '1.5.0'
@@ -73,10 +75,12 @@ cdef class File:
     cdef readonly list unsupported
 
     def __cinit__(self, path):
-        if not isinstance(path, unicode):
-            path = path.decode('utf8')
+        if not isinstance(path, PathLike):
+            if not isinstance(path, unicode):
+                path = path.decode('utf8')
+            path = Path(path)
         self.path = path
-        self.bPath = path.encode('utf8')
+        self.bPath = str(path).encode('utf8')
         IF UNAME_SYSNAME == "Windows":
             # create on windows takes wchar_t* which Cython automatically converts to
             # from unicode strings


### PR DESCRIPTION
This PR allows PathLike parameters in the File constructor and makes the File.path member a pathlib.Path. Fixes #40.

Not sure if you would want to break the API by changing the Type of File.path. Maybe introducing another member and exposing the Path that way, while keeping the string for File.path would be better. What's your opinion? I'll change it accordingly.

Also there are is no test for the PathLike parameter. I'll write one if you want that tested.